### PR TITLE
Titleタグを利用しないように修正

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,4 +1,7 @@
-# NDExt Release Notes
+#  Next Design Extension Project Templates Release Notes
+
+## 1.1.0
+* Next Design V2.0 Service Update1で`title`タグ利用の廃止に連動し、説明の１行目がタイトルである記載を削除。
 
 ## 1.0.2
 * Visual Studio 2019/2022での検証

--- a/src/NdExtension.ProjectTemplates.csproj
+++ b/src/NdExtension.ProjectTemplates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.0.3</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <PackageId>NextDesign.Extension.ProjectTemplates</PackageId>
     <Title>Next Design Extension Templates</Title>
     <Authors>DENSO CREATE INC.</Authors>
@@ -21,7 +21,7 @@
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Company>DENSO CREATE INC.</Company>
     <Product>NextDesign.Extension.ProjectTemplates</Product>
     <Copyright>DENSO CREATE INC.</Copyright>

--- a/src/templates/NdExtension/NdExtension.csproj
+++ b/src/templates/NdExtension/NdExtension.csproj
@@ -9,9 +9,7 @@
     <Authors>Me</Authors>
     <Company>Me</Company>
     <Product>NdExtension</Product>
-    <Description>NdExtensionのタイトル
-ここからNdExtensionの説明を記載して下さい。
-</Description>
+    <Description>NdExtensionの説明です。</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/templates/NdExtensionPoints/NdExtensionPoints.csproj
+++ b/src/templates/NdExtensionPoints/NdExtensionPoints.csproj
@@ -9,9 +9,7 @@
     <Authors>Me</Authors>
     <Company>Me</Company>
     <Product>NdExtension</Product>
-    <Description>NdExtensionのタイトル
-ここからNdExtensionの説明を記載して下さい。
-</Description>
+    <Description>NdExtensionの説明です。</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <AssemblyName>NdExtension</AssemblyName>
     <RootNamespace>NdExtension</RootNamespace>


### PR DESCRIPTION
Next Design V2.0 Service Update 1のパッケージで`title`タグの利用を廃止した事に伴い、`Description`の１行目がタイトルである記載を削除。