### PR TITLE
テンプレートのデフォルトのターゲットフレームワークをNET6に変更

### DIFF
--- a/src/templates/NdExtension/.template.config/template.json
+++ b/src/templates/NdExtension/.template.config/template.json
@@ -22,12 +22,12 @@
         "datatype": "choice",
         "choices": [
         {
-            "choice": "netcoreapp3.1",
-            "description": "Target netcoreapp3.1"
+            "choice": "net6.0",
+            "description": "Target net6.0"
         }
         ],
-        "replaces": "netcoreapp3.1",
-        "defaultValue": "netcoreapp3.1"
+        "replaces": "net6.0",
+        "defaultValue": "net6.0"
       }
     }
 }

--- a/src/templates/NdExtension/NdExtension.csproj
+++ b/src/templates/NdExtension/NdExtension.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <PackageId>NdExtension</PackageId>
     <Version>1.0.0</Version>

--- a/src/templates/NdExtension/manifest.schema.json
+++ b/src/templates/NdExtension/manifest.schema.json
@@ -101,6 +101,22 @@
           }
         }
       }
+    },
+    "runtime": {
+      "type": "object",
+      "properties": {
+        "sharedAssemblies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "required": [ "name", "main", "lifecycle" ],

--- a/src/templates/NdExtensionPoints/.template.config/template.json
+++ b/src/templates/NdExtensionPoints/.template.config/template.json
@@ -23,12 +23,12 @@
       "datatype": "choice",
       "choices": [
       {
-          "choice": "netcoreapp3.1",
-          "description": "Target netcoreapp3.1"
+          "choice": "net6.0",
+          "description": "Target net6.0"
       }
       ],
-      "replaces": "netcoreapp3.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
     }
   }
 }

--- a/src/templates/NdExtensionPoints/NdExtensionPoints.csproj
+++ b/src/templates/NdExtensionPoints/NdExtensionPoints.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <PackageId>NdExtension</PackageId>
     <Version>1.0.0</Version>

--- a/src/templates/NdExtensionPoints/manifest.schema.json
+++ b/src/templates/NdExtensionPoints/manifest.schema.json
@@ -101,6 +101,22 @@
           }
         }
       }
+    },
+    "runtime": {
+      "type": "object",
+      "properties": {
+        "sharedAssemblies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "required": [ "name", "main", "lifecycle" ],


### PR DESCRIPTION
## 位置づけ
このプルリクエストは、以下に対応します。
* テンプレートのデフォルトのターゲットフレームワークをNET6に変更
  * ![image](https://github.com/denso-create/NextDesign-Extension-ProjectTemplates/assets/54836263/11b9aae7-1543-4744-9390-17c5352d2773)

* Jsonスキーマファイルに `runtime` 属性を追加

## CRレビュー観点
以下のCRレビュー観点について確認しました。

凡例：
- [x]：確認済み
- [-]：確認対象外

### コメント
- [-] クラスヘッダには、責務範囲を判断できるようなコメントが書かれているか。
- [-] メソッドヘッダでは、引数の境界（特にnullの扱い）や単位がわかるようなコメントが書かれているか。
- [-] ブロック単位で、それが何をしているか、意味的なコメントが記述されているか。
- [-] 使用している用語は仕様に定められているものと整合しているか。

### 命名規則
- [-] クラス名、メソッド名、フィールド名は適切か。単語を省略していないか。 
- [-] マジックナンバーをコード中に記載していないか。
- [-] 実装したコードの前後に類似処理が実装されていたり、コメント不備が残っていないか。 
- [-] 命名には一貫性があるか。入力文書で定められた用語を用いているか。 

### ロジック
- [-] MVVM原則に違反し、Viewにコードビハインドを記述したり、ViewがModelを参照したりしていないか。
- [-] ViewModelがModelへの参照を保持する場合、すべて（コレクションを含めて）弱参照としているか。
- [-] ループの入れ子や再帰呼び出しにより計算量が大きくなり応答性を低下させていないか。
- [-] プロパティのsetterで状態変更やイベント発行以外のビジネスロジックが実装されていないか。
- [-] イベントハンドラは入力チェックと処理の流れ・分岐のみで、ロジックを直接記述していないか。
- [-] staticなフィールドを追加していないか。
- [-] 必要以上に広いアクセシビリティになっていないか。
- [-] イベントハンドラの接続・切断は対応づいているか。
- [-] IDisposableなオブジェクトはusing句を使って必ずDisposeされるようになっているか。 
- [-] ループ処理の中で条件分岐を記述していないか。（ループ処理の中での条件分岐は禁止）
- [-] 冗長なコードやコピーコードが存在していないか。

### 国際対応
- [-] リテラル文字列を記述せずにリソース化しているか。 
- [-] 文字列リソースのIDは命名規則に従っているか。

### 類似不具合の除去
- [-] 不具合修正の際は、類似不具合が存在しないか。

### 入力文書との対応
- [-] 入力文書で定義された内容の実装漏れがないか。
- [-] 入力文書の不備があった場合、文書の作成者や成果物の承認者に確認し、すべて解消しているか。

### 課題を登録する場合
- [-] なぜその課題に対応しなければならないかが分かるか。
- [-] 第三者が見ても理解できる記載となっているか。

## デバッグ確認

[修正確認観点]
- テンプレートを使用してプロジェクトを新規作成した際、ターゲットフレームワークの選択画面で「.NET 6.0」がデフォルトで表示されること。
  - [x] ExtensionPointsなしのテンプレート
  - [x] ExtensionPointsありのテンプレート
- テンプレートを使用して新規作成したプロジェクトがビルドでき、エクステンションが動作すること。
  - [x] ExtensionPointsなしのテンプレート
  - [x] ExtensionPointsありのテンプレート
- manifest.json の編集時に runtime 属性が入力候補に表示されること。
  - [x] ExtensionPointsなしのテンプレート
  - [x] ExtensionPointsありのテンプレート
- 入力候補に従って定義した runtime 属性（共有ライブラリの指定）が動作すること。
  - [x] ExtensionPointsなしのテンプレート
  - [x] ExtensionPointsありのテンプレート

[デグレード確認観点]
- その他のJsonスキーマの項目に変化がないこと
　　⇒CRで確認。