### PR TITLE
テンプレートから作成されるプロジェクトのバージョン番号の初期値を修正

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@
 - [リリースノート](#リリースノート)
 - [利用方法](#利用方法)
 - [テンプレートの開発](#テンプレートの開発)
+- [パッケージの作成方法](#パッケージの作成方法) 
 - [nuget.orgへのパッケージの公開方法](#nugetorgへのパッケージの公開方法)
   - [ローカルから公開する方法](#ローカルから公開する方法)
   - [Github Actionsによる公開](#github-actionsによる公開)
@@ -39,6 +40,10 @@
 * [.NET CLI Templates in Visual Studio](https://devblogs.microsoft.com/dotnet/net-cli-templates-in-visual-studio/)
 * [how to create templates that work in dotnet new and Visual Studio/Visual Studio for Mac](https://github.com/sayedihashimi/template-sample)
 * [How do I ship multiple `dotnet new` templates inside a single NuGet package?](https://stackoverflow.com/questions/58325232/how-do-i-ship-multiple-dotnet-new-templates-inside-a-single-nuget-package)
+
+## パッケージの作成方法
+
+[こちら](https://github.com/miles-team/NextDesign/wiki/エクステンション開発プロジェクトテンプレート-パッケージ作成手順)を参照してください。
 
 ## nuget.orgへのパッケージの公開方法
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,5 +1,8 @@
 #  Next Design Extension Project Templates Release Notes
 
+## 1.2.3
+* 作成されるプロジェクトのバージョン番号の初期値を 1.0.0 に修正しました。
+
 ## 1.2.2
 * pkgContentsフォルダ以下に「profiles」フォルダを作成したため、ユーザが自分でフォルダを作らずにベースプロファイルを配布できるようになりました。
 

--- a/src/NdExtension.ProjectTemplates.csproj
+++ b/src/NdExtension.ProjectTemplates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.2.2</PackageVersion>
+    <PackageVersion>1.2.3</PackageVersion>
     <PackageId>NextDesign.Extension.ProjectTemplates</PackageId>
     <Title>Next Design Extension Templates</Title>
     <Authors>DENSO CREATE INC.</Authors>

--- a/src/templates/NdExtensionPoints/NdExtensionPoints.csproj
+++ b/src/templates/NdExtensionPoints/NdExtensionPoints.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <PackageId>NdExtension</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.0</Version>
     <PackageProjectUrl>https://www.your-web-here.com/</PackageProjectUrl>
     <Authors>Me</Authors>
     <Company>Me</Company>


### PR DESCRIPTION
## 検証観点とデバッグ確認

### デバッグ項目
以下のデバッグ確認(効果確認、デグレード確認)を実施しました。

#### 効果確認

- [x] Next Design Extension (Extension Points) でプロジェクトを作成するとバージョンの初期値が「1.0.0」であること

#### デグレード確認

- パッケージを指定してインストールすると、以前と同じ2つのテンプレートをインストールできること
  - [x] Next Design Extension（短い名前：ndext）
  - [x] Next Design Extension (Extension Points) （短い名前：ndextp）